### PR TITLE
Replace "browser" -> "rollup:dist"

### DIFF
--- a/packages/brookjs-desalinate/package.json
+++ b/packages/brookjs-desalinate/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0-alpha.1",
   "description": "testing tools for brookjs applications",
   "main": "dist/brookjs-desalinate.cjs.js",
-  "browser": "dist/brookjs-desalinate.umd.js",
   "module": "dist/brookjs-desalinate.esm.js",
+  "rollup:dist": "dist/brookjs-desalinate.umd.js",
   "keywords": [
     "kefir",
     "browser",

--- a/packages/brookjs-silt/package.json
+++ b/packages/brookjs-silt/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0-alpha.1",
   "description": "reactive programming with reactjs",
   "main": "dist/brookjs-silt.cjs.js",
-  "browser": "dist/brookjs-silt.umd.js",
   "module": "dist/brookjs-silt.esm.js",
+  "rollup:dist": "dist/brookjs-silt.umd.js",
   "scripts": {
     "test": "npm run test:lint && npm run test:unit",
     "test:lint": "eslint src --fix",

--- a/packages/brookjs/package.json
+++ b/packages/brookjs/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0-alpha.1",
   "description": "reactive programming tools for well-structured, testable applications",
   "main": "dist/brookjs.cjs.js",
-  "browser": "dist/brookjs.umd.js",
   "module": "dist/brookjs.esm.js",
+  "rollup:dist": "dist/brookjs.dist.js",
   "files": [
     "dist",
     "src"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,7 @@ const cjs = {
 export default [
     {
         input: 'src/index.js',
-        output: { name: pkg.name, file: pkg.browser, format: 'umd' },
+        output: { name: pkg.name, file: pkg['rollup:dist'], format: 'umd' },
         plugins: [
             babel(),
             resolve(),


### PR DESCRIPTION
This allows us to configure the output file in each package while
sharing a single configuration.

Fixes #262.