### PR TITLE
Add loose equality check to ofType

### DIFF
--- a/packages/brookjs/src/__tests__/ofType.spec.js
+++ b/packages/brookjs/src/__tests__/ofType.spec.js
@@ -1,0 +1,74 @@
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import { chaiPlugin } from 'brookjs-desalinate';
+import Kefir from 'kefir';
+import ofType from '../ofType';
+
+const { plugin, send, value, stream } = chaiPlugin({ Kefir });
+use(plugin);
+
+describe('ofType', () => {
+    it('should match when passing one type', () => {
+        const action$ = stream();
+
+        expect(action$.thru(ofType('MATCHED')))
+            .to.emit([value({ type: 'MATCHED' })], () => {
+                send(action$, [
+                    value({ type: 'UNMATCHED' }),
+                    value({ type: 'MATCHED' })
+                ]);
+            });
+    });
+
+    it('should match when passing one type with Function#toString', () => {
+        const matched = () => {};
+        matched.toString = () => 'MATCHED';
+        const action$ = stream();
+
+        expect(action$.thru(ofType(matched)))
+            .to.emit([value({ type: 'MATCHED' })], () => {
+                send(action$, [
+                    value({ type: 'UNMATCHED' }),
+                    value({ type: 'MATCHED' })
+                ]);
+            });
+    });
+
+    it('should match when passing multiple types', () => {
+        const action$ = stream();
+
+        expect(action$.thru(ofType('MATCHED_ONE', 'MATCHED_TWO')))
+            .to.emit([
+                value({ type: 'MATCHED_ONE' }),
+                value({ type: 'MATCHED_TWO' })
+            ], () => {
+                send(action$, [
+                    value({ type: 'MATCHED_ONE' }),
+                    value({ type: 'UNMATCHED' }),
+                    value({ type: 'MATCHED_TWO' }),
+                    value({ type: 'UNMATCHED_AGAIN' }),
+                ]);
+            });
+    });
+
+    it('should match when passing multiple types with Function#toString', () => {
+        const matchedOne = () => {};
+        matchedOne.toString = () => 'MATCHED_ONE';
+        const matchedTwo = () => {};
+        matchedTwo.toString = () => 'MATCHED_TWO';
+        const action$ = stream();
+
+        expect(action$.thru(ofType(matchedOne, matchedTwo)))
+            .to.emit([
+                value({ type: 'MATCHED_ONE' }),
+                value({ type: 'MATCHED_TWO' })
+            ], () => {
+                send(action$, [
+                    value({ type: 'MATCHED_ONE' }),
+                    value({ type: 'UNMATCHED' }),
+                    value({ type: 'MATCHED_TWO' }),
+                    value({ type: 'UNMATCHED_AGAIN' }),
+                ]);
+            });
+    });
+});

--- a/packages/brookjs/src/ofType.js
+++ b/packages/brookjs/src/ofType.js
@@ -3,9 +3,15 @@
  * takes an Observable of actions and filters them based on the
  * types provided. Reads `action.type` to match.
  *
+ * Checks loosely against action.type, which should always be
+ * a string, as this is intended to be used with with the actions
+ * emitted from a Redux store. This is exposed so it works with
+ * redux-actions' action creator functions, which come with
+ * `toString` to allow loose comparison.
+ *
  * Intended to be used with Kefir's `thru` method.
  *
- * @param {string[]} types - Action types to filter by
+ * @param {string[]} types - Action types to filter by.
  * @returns {function(*=): (*|this)} Observable filtering function.
  */
 const ofType = (...types) => obs$ => obs$.filter(action => {
@@ -13,10 +19,12 @@ const ofType = (...types) => obs$ => obs$.filter(action => {
     const len = types.length;
 
     if (len === 1) {
-        return type === types[0];
+        // eslint-disable-next-line eqeqeq
+        return type == types[0];
     } else {
         for (let i = 0; i < len; i++) {
-            if (types[i] === type) {
+            // eslint-disable-next-line eqeqeq
+            if (types[i] == type) {
                 return true;
             }
         }


### PR DESCRIPTION
This enables usage with redux-actions, as those functions are castable
to strings.

Fixes #270.