### PR TITLE
Add combineReducers and clean up tests

### DIFF
--- a/packages/brookjs/src/__tests__/eddy.spec.js
+++ b/packages/brookjs/src/__tests__/eddy.spec.js
@@ -1,79 +1,126 @@
 /* eslint-env mocha */
 import { expect } from 'chai';
 import { createStore } from 'redux';
-import { eddy, loop } from '../eddy';
+import { eddy, loop, combineReducers } from '../eddy';
 
 describe('eddy', () => {
-    const defaultState = {
-        actions: []
-    };
+    describe('enhance store', () => {
+        const defaultState = {
+            actions: []
+        };
 
-    const reducer = (state = defaultState, action) => {
-        switch (action.type) {
-            case 'HOLD':
-                return {
-                    actions: [...state.actions, action.type]
-                };
-            case 'NEXT':
-                return loop({
-                    actions: [...state.actions, action.type]
-                }, {
-                    type: 'HOLD'
-                });
-            case 'MANY':
-                return loop({
-                    actions: [...state.actions, action.type]
-                }, [{ type: 'HOLD' }, { type: 'FINAL' }]);
-            case 'FINAL':
-                return loop({
-                    actions: [...state.actions, action.type]
-                }, loop.NONE);
-            default:
-                return state;
-        }
-    };
+        const reducer = (state = defaultState, action) => {
+            switch (action.type) {
+                case 'HOLD':
+                    return {
+                        actions: [...state.actions, action.type]
+                    };
+                case 'NEXT':
+                    return loop({
+                        actions: [...state.actions, action.type]
+                    }, {
+                        type: 'HOLD'
+                    });
+                case 'MANY':
+                    return loop({
+                        actions: [...state.actions, action.type]
+                    }, [{ type: 'HOLD' }, { type: 'FINAL' }, loop.NONE]);
+                case 'FINAL':
+                    return loop({
+                        actions: [...state.actions, action.type]
+                    }, loop.NONE);
+                default:
+                    return state;
+            }
+        };
 
-    let store;
+        let store;
 
-    beforeEach(() => {
-        store = createStore(reducer, eddy());
-    });
+        beforeEach(() => {
+            store = createStore(reducer, eddy());
+        });
 
-    it('should return a redux store', () => {
-        expect(store.subscribe).to.be.a('function');
-        expect(store.getState).to.be.a('function');
-        expect(store.getState()).to.equal(defaultState);
-    });
+        it('should return a redux store', () => {
+            expect(store.subscribe).to.be.a('function');
+            expect(store.getState).to.be.a('function');
+            expect(store.getState()).to.equal(defaultState);
+        });
 
-    it('should handle normal actions by default', () => {
-        store.dispatch({ type: 'HOLD' });
+        it('should upgrade new reducers', () => {
+            const defaultState = {
+                dispatches: []
+            };
+            const reducer = () => defaultState;
+            store.replaceReducer(reducer);
+            expect(store.getState()).to.equal(defaultState);
+        });
 
-        expect(store.getState()).to.deep.equal({
-            actions: ['HOLD']
+        it('should handle normal actions by default', () => {
+            store.dispatch({ type: 'HOLD' });
+
+            expect(store.getState()).to.deep.equal({
+                actions: ['HOLD']
+            });
+        });
+
+        it('should dispatch actions returned by loop', () => {
+            store.dispatch({ type: 'NEXT' });
+
+            expect(store.getState()).to.deep.equal({
+                actions: ['NEXT', 'HOLD']
+            });
+        });
+
+        it('should dispatch array of actions', () => {
+            store.dispatch({ type: 'MANY' });
+
+            expect(store.getState()).to.deep.equal({
+                actions: ['MANY', 'HOLD', 'FINAL']
+            });
+        });
+
+        it('should not dispatch action with NONE', () => {
+            store.dispatch({ type: 'FINAL' });
+
+            expect(store.getState()).to.deep.equal({
+                actions: ['FINAL']
+            });
         });
     });
 
-    it('should dispatch actions returned by loop', () => {
-        store.dispatch({ type: 'NEXT' });
+    describe('combineReducers', () => {
+        const reducerMap = {
+            pings: (state = 0, action) => action.type === 'PING' && state < 2
+                ? loop(state + 1, { type: 'PONG' })
+                : state,
+            pongs: (state = 0, action) => action.type === 'PONG' && state < 2
+                ? loop(state + 1, { type: 'PING' })
+                : state,
+        };
 
-        expect(store.getState()).to.deep.equal({
-            actions: ['NEXT', 'HOLD']
+        const reducer = combineReducers(reducerMap);
+        let store;
+
+        beforeEach(() => {
+            store = createStore(reducer, eddy());
         });
-    });
 
-    it('should dispatch array of actions', () => {
-        store.dispatch({ type: 'MANY' });
-
-        expect(store.getState()).to.deep.equal({
-            actions: ['MANY', 'HOLD', 'FINAL']
+        it('should return a reducer function', () => {
+            expect(reducer).to.be.a('function');
         });
-    });
 
-    it('should not dispatch action with NONE', () => {
-        store.dispatch({ type: 'FINAL' });
+        it('should dispatch actions returned from subreducers', () => {
+            store.dispatch({ type: 'PING' });
+            expect(store.getState()).to.deep.equal({
+                pings: 2,
+                pongs: 2
+            });
+        });
 
-        expect(store.getState()).to.deep.equal({
-            actions: ['FINAL']
+        it('should return same state if unchanged', () => {
+            const prevState = store.getState();
+            store.dispatch({ type: 'OTHER' });
+            expect(store.getState()).to.equal(prevState);
         });
     });
 });

--- a/packages/brookjs/src/index.js
+++ b/packages/brookjs/src/index.js
@@ -1,7 +1,8 @@
-import { eddy, loop } from './eddy';
+import { eddy, loop, combineReducers } from './eddy';
 import { raf$, RAF } from './rAF';
 import fromReduxStore from './fromReduxStore';
 import ofType from './ofType';
 import observeDelta from './observeDelta';
 
-export { observeDelta, ofType, RAF, fromReduxStore, raf$, eddy, loop };
+export { observeDelta, ofType, RAF, fromReduxStore, raf$, eddy, loop,
+    combineReducers };


### PR DESCRIPTION
100% coverage of the eddy module! Add returning `loop.NONE` from one of the
arrays, to ensure we get coverage of the `!== NONE` branch. Also fixed a bug
in the `runCommands`, which was calling the original `store.dispatch` instead
of the wrapped `dispatch` function. This would terminate the continuous dispatch
of the returned actions.