### PR TITLE
Make toJunction composable

### DIFF
--- a/packages/brookjs-silt/src/__tests__/toJunction.spec.js
+++ b/packages/brookjs-silt/src/__tests__/toJunction.spec.js
@@ -18,11 +18,11 @@ describe('toJunction', () => {
     const events = { onButtonClick: e$ => e$.map(() => ({ type: 'CLICK' })) };
 
     describe('events', () => {
-        const Button = toJunction(({ onButtonClick, text, enabled }) => (
+        const Button = toJunction({ events })(({ onButtonClick, text, enabled }) => (
             enabled ? <button onClick={onButtonClick}>
                 {text}
             </button> : <span>nothing to click</span>
-        ), { events });
+        ));
 
         const ProvidedButton = ({ root$, text, enabled }) => (
             <Provider value={root$}>
@@ -105,11 +105,11 @@ describe('toJunction', () => {
         it('should call combine with correct arguments and use returned stream', () => {
             const source$ = stream();
             const combine = sinon.spy(() => source$);
-            const Button = toJunction(({ onButtonClick, text, enabled }) => (
+            const Button = toJunction({ combine, events })(({ onButtonClick, text, enabled }) => (
                 enabled ? <button onClick={onButtonClick}>
                     {text}
                 </button> : <span>nothing to click</span>
-            ), { combine, events });
+            ));
 
             const ProvidedButton = ({ root$, text, enabled }) => (
                 <Provider value={root$}>
@@ -134,11 +134,11 @@ describe('toJunction', () => {
 
         it('should call combine with updated props', () => {
             const combine = sinon.spy(() => Kefir.never());
-            const Button = toJunction(({ onButtonClick, text, enabled }) => (
+            const Button = toJunction({ combine, events })(({ onButtonClick, text, enabled }) => (
                 enabled ? <button onClick={onButtonClick}>
                     {text}
                 </button> : <span>nothing to click</span>
-            ), { combine, events });
+            ));
 
             const ProvidedButton = ({ root$, text, enabled }) => (
                 <Provider value={root$}>

--- a/packages/brookjs-silt/src/toJunction.js
+++ b/packages/brookjs-silt/src/toJunction.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import Kefir from 'kefir';
+// eslint-disable-next-line import/no-internal-modules
 import wrapDisplayName from 'recompose/wrapDisplayName';
 import h from './h';
 import { Consumer } from './context';
 
-export default function toJunction(Component, { events, combine = x => x }) {
+const toJunction = ({ events, combine = x => x }) => WrappedComponent => {
     class ToJunction extends React.Component {
         constructor(props, context) {
             super(props, context);
@@ -58,14 +59,16 @@ export default function toJunction(Component, { events, combine = x => x }) {
                             this.root$ = root$.plug(this.source$);
                         }
 
-                        return <Component {...this.props} {...this.events} />;
+                        return <WrappedComponent {...this.events} {...this.props} />;
                     }}
                 </Consumer>
             );
         }
     }
 
-    ToJunction.displayName = wrapDisplayName(Component, 'ToJunction');
+    ToJunction.displayName = wrapDisplayName(WrappedComponent, 'ToJunction');
 
     return ToJunction;
-}
+};
+
+export default toJunction;


### PR DESCRIPTION
This is a breaking change, but enables toJunction to be more easily composed.
It also swaps the ordering of props & events, allowing parents to pass in their
own `onX` events if they prefer, rather than pushing those values into the stream.

Fixes #271.