### PR TITLE
Fix withRef$ API

### DIFF
--- a/packages/brookjs-silt/src/withRef.js
+++ b/packages/brookjs-silt/src/withRef.js
@@ -5,16 +5,30 @@ import wrapDisplayName from 'recompose/wrapDisplayName';
 import Kefir from 'kefir';
 import { Consumer } from './context';
 
-export default function withRef$(c, callback) {
-    const Reffed = forwardRef(c);
+const wrap = WrappedComponent => {
+    // Ref-forward function has 2 params.
+    if (WrappedComponent.length === 2) {
+        return forwardRef(WrappedComponent);
+    }
 
-    class WithRef extends React.Component {
-        constructor(props, context) {
-            super(props, context);
-            this.ref$ = new Kefir.Property();
-            this.ref = createRef();
-            this.el = null;
-        }
+    return WrappedComponent;
+};
+
+const withRef$ = refback => WrappedComponent =>
+    class WithRef$ extends React.Component {
+        static displayName = wrapDisplayName(WrappedComponent, 'WithRef$');
+
+        static Target = wrap(WrappedComponent);
+
+        ref = createRef();
+
+        props$ = new Kefir.Stream()
+            .toProperty(() => this.props)
+            .setName(`${WithRef$.displayName}#props$`);
+
+        ref$ = new Kefir.Stream()
+            .toProperty(() => getRef(this.ref))
+            .setName(`${WithRef$.displayName}#ref$`);
 
         componentWillUnmount() {
             this.aggregated$.unplug(this.plugged$);
@@ -23,34 +37,38 @@ export default function withRef$(c, callback) {
         componentDidMount() {
             const el = getRef(this.ref);
 
-            if (el && this.el !== el) {
+            if (el) {
                 this.ref$._emitValue(el);
-                this.el = el;
             }
+        }
+
+        componentDidUpdate() {
+            this.emitProps();
+        }
+
+        emitProps() {
+            this.props$._emitValue(this.props);
         }
 
         render() {
             return (
                 <Consumer>
                     {aggregated$ => {
-                        if (this.plugged$) {
+                        if (this.plugged$ && this.aggregated$ !== aggregated$) {
                             this.aggregated$.unplug(this.plugged$);
+                            this.aggregated$ = aggregated$.plug(this.plugged$);
                         }
 
                         if (!this.plugged$) {
-                            this.plugged$ = callback(this.ref$, this.props);
+                            this.plugged$ = refback(this.ref$, this.props$);
+                            this.aggregated$ = aggregated$.plug(this.plugged$);
                         }
 
-                        this.aggregated$ = aggregated$.plug(this.plugged$);
-
-                        return <Reffed {...this.props} ref={this.ref} />;
+                        return <WithRef$.Target {...this.props} ref={this.ref} />;
                     }}
                 </Consumer>
             );
         }
-    }
+    };
 
-    WithRef.displayName = wrapDisplayName(Reffed, 'WithRef');
-
-    return WithRef;
-};
+export default withRef$;


### PR DESCRIPTION
Update the API to be properly composable. Fix the parameters passed to
withRef$ so they get two streams, the second of which is a stream of props.

Fixes #229.