### PR TITLE
Extract and export Refback type

### DIFF
--- a/packages/brookjs-silt/src/__tests__/withRef.spec.tsx
+++ b/packages/brookjs-silt/src/__tests__/withRef.spec.tsx
@@ -4,7 +4,7 @@ import Kefir from 'kefir';
 import React from 'react';
 import { chaiPlugin } from 'brookjs-desalinate';
 import { render } from 'react-testing-library';
-import withRef$ from '../withRef';
+import { withRef$ } from '../withRef';
 import { Provider } from '../context';
 
 const { plugin, value } = chaiPlugin({ Kefir });

--- a/packages/brookjs-silt/src/index.ts
+++ b/packages/brookjs-silt/src/index.ts
@@ -1,6 +1,6 @@
 import RootJunction from './RootJunction';
 import toJunction from './toJunction';
 import view from './view';
-import withRef$ from './withRef';
 
-export { RootJunction, toJunction, view, withRef$ };
+export * from './withRef';
+export { RootJunction, toJunction, view };

--- a/packages/brookjs-silt/src/withRef.tsx
+++ b/packages/brookjs-silt/src/withRef.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, createRef } from 'react';
+import React, { forwardRef } from 'react';
 // eslint-disable-next-line import/no-internal-modules
 import wrapDisplayName from 'recompose/wrapDisplayName';
 import Kefir, { Pool, Observable, Property } from 'kefir';
@@ -21,12 +21,14 @@ const wrap = <T, P>(
   return WrappedComponent;
 };
 
-const withRef$ = <P, E extends Element>(
-  refback: (
-    ref$: Property<E, never>,
-    props$: Observable<P, never>
-  ) => Observable<Action, Error>
-) => (WrappedComponent: React.RefForwardingComponent<E, P>) =>
+export type Refback<P, E extends Element> = (
+  ref$: Property<E, never>,
+  props$: Observable<P, never>
+) => Observable<Action, Error>;
+
+export const withRef$ = <P, E extends Element>(refback: Refback<P, E>) => (
+  WrappedComponent: React.RefForwardingComponent<E, P>
+) =>
   class WithRef$ extends React.Component<P> {
     static displayName = wrapDisplayName(WrappedComponent, 'WithRef$');
 
@@ -88,5 +90,3 @@ const withRef$ = <P, E extends Element>(
       );
     }
   };
-
-export default withRef$;


### PR DESCRIPTION
This can be used by consumers to make defining the Refback
function easier.