### PR TITLE
Add missing types to brookjs-desalinate

### DIFF
--- a/packages/brookjs-desalinate/package.json
+++ b/packages/brookjs-desalinate/package.json
@@ -46,13 +46,13 @@
     "polished": "^3.2.0",
     "react": "^16.8.0",
     "react-inspector": "^2.3.1",
-    "react-testing-library": "^7.0.0",
     "uuid": "^3.3.2"
   },
   "peerDependencies": {
     "chai": "^4.0.0",
     "jest": "^24.0.0",
-    "kefir": "^3.8.0"
+    "kefir": "^3.8.0",
+    "react-testing-library": "^7.0.0"
   },
   "gitHead": "b70ddce5231a58a1568bc86737756b42a73a7686"
 }

--- a/packages/brookjs-desalinate/src/chaiPlugin.tsx
+++ b/packages/brookjs-desalinate/src/chaiPlugin.tsx
@@ -16,6 +16,7 @@ declare global {
     interface Assertion {
       emit: Emit<Assertion>;
       emitFromDelta: EmitFromDelta<Assertion>;
+      emitFromJunction: EmitFromJunction<Assertion>;
     }
 
     interface TypeComparison {
@@ -32,7 +33,12 @@ export type Tick = (time: number) => void;
 export type Emit<A> = <V, E>(expected: Array<Event<V, E>>, cb: () => void) => A;
 export type EmitFromDelta<A> = <V, E>(
   expected: Array<[number, Event<V, E>]>,
-  cb?: (sendToDelta: ToDelta, tick: Tick) => void,
+  cb?: (sendToDelta: ToDelta, tick: Tick, clock: Clock) => void,
+  options?: { timeLimit?: number }
+) => A;
+export type EmitFromJunction<A> = <V, E>(
+  expected: Array<[number, Event<V, E>]>,
+  cb?: (api: ReturnType<typeof render>, tick: Tick, clock: Clock) => void,
   options?: { timeLimit?: number }
 ) => A;
 


### PR DESCRIPTION
Forgot to add the last assertion to chai.