### PR TITLE
Fix toJunction typings

### DIFF
--- a/packages/brookjs-cli/src/commands/NewCommand/View.tsx
+++ b/packages/brookjs-cli/src/commands/NewCommand/View.tsx
@@ -221,10 +221,10 @@ const View: React.FC<Props> = props => {
 
 const events = {
   onChange: (e$: Observable<string, Error>) =>
-    e$.map((value: string) => ({ type: 'INPUT', payload: { value } })),
+    e$.map(value => ({ type: 'INPUT', payload: { value } })),
   onSubmit: (e$: Observable<void, Error>) => e$.map(() => ({ type: 'SUBMIT' })),
   onConfirm: (e$: Observable<boolean, Error>) =>
-    e$.map((value: boolean) => ({ type: 'CONFIRM', payload: { value } }))
+    e$.map(value => ({ type: 'CONFIRM', payload: { value } }))
 };
 
-export default toJunction<Props, typeof events>(events)(View);
+export default toJunction(events)(View);

--- a/packages/brookjs-cli/src/commands/NewCommand/index.tsx
+++ b/packages/brookjs-cli/src/commands/NewCommand/index.tsx
@@ -188,5 +188,5 @@ export default class NewCommand extends Command<
   };
 
   // @TODO(mAAdhaTTah) This needs to actually work.
-  View = View as any;
+  View = View as React.ComponentType<State>;
 }

--- a/packages/brookjs-silt/src/toJunction.tsx
+++ b/packages/brookjs-silt/src/toJunction.tsx
@@ -3,8 +3,8 @@ import Kefir, { Observable, Pool } from 'kefir';
 // eslint-disable-next-line import/no-internal-modules
 import wrapDisplayName from 'recompose/wrapDisplayName';
 import { Action } from 'redux';
-import { Omit } from 'yargs';
 import { Consumer, Provider } from './context';
+import { Omit } from 'recompose';
 
 const id = <T extends any>(x: T) => x;
 
@@ -12,126 +12,150 @@ type EventConfig = {
   [key: string]: (e$: Observable<any, Error>) => Observable<Action, Error>;
 };
 
-type ObservableDict = { [key: string]: Observable<Action, Error> };
-
-type FirstArgument<T> = T extends (arg1: infer U, ...args: any[]) => any
-  ? U
-  : never;
-
-type ExtractValue<V> = V extends Observable<infer E, any> ? E : never;
-
-type ExtraProps<E extends EventConfig> = {
-  [K in keyof E]: (e: ExtractValue<FirstArgument<E[K]>>) => void
+type ObservableDict<E extends EventConfig> = {
+  [key in keyof E]: Observable<Action, Error>
+} & {
+  children$: Observable<Action, Error>;
 };
 
-type WithPreplug<P extends object> = P & {
+type ExtractFirstArgumentValue<T> = T extends (
+  arg1: Observable<infer E, any>,
+  ...args: any[]
+) => any
+  ? E
+  : never;
+
+type ProvidedProps<E extends EventConfig> = {
+  [K in keyof E]: (e: ExtractFirstArgumentValue<E[K]>) => void
+};
+
+type WithProps<E extends EventConfig, P extends ProvidedProps<E>> = Omit<
+  P,
+  keyof E
+> & {
   preplug?: (source$: Observable<Action, Error>) => Observable<Action, Error>;
 };
 
-const toJunction = <P extends object, E extends EventConfig>(
+type Combiner<E extends EventConfig, P extends ProvidedProps<E>> = (
+  combined$: Observable<Action, Error>,
+  sources: ObservableDict<E>,
+  props: Readonly<WithProps<E, P>>
+) => Observable<Action, Error>;
+
+function toJunction<E extends EventConfig>(
+  events: E
+): <P extends ProvidedProps<E>>(
+  WrappedComponent: React.ComponentType<P>
+) => React.ComponentType<WithProps<E, P>>;
+function toJunction<E extends EventConfig, P extends ProvidedProps<E>>(
   events: E,
-  combine: (
-    combined$: Observable<Action, Error>,
-    sources: ObservableDict,
-    props: Readonly<WithPreplug<Omit<P, keyof E>>>
-  ) => Observable<Action, Error> = id
-) => (WrappedComponent: React.ComponentType<P>) =>
-  class ToJunction extends React.Component<WithPreplug<Omit<P, keyof E>>> {
-    static displayName = wrapDisplayName(WrappedComponent, 'ToJunction');
+  combine: Combiner<E, P>
+): (
+  WrappedComponent: React.ComponentType<P>
+) => React.ComponentType<WithProps<E, P>>;
+function toJunction<E extends EventConfig, P extends ProvidedProps<E>>(
+  events: E,
+  combine: Combiner<E, P> = id
+) {
+  return (
+    WrappedComponent: React.ComponentType<P>
+  ): React.ComponentType<WithProps<E, P>> =>
+    class ToJunction extends React.Component<WithProps<E, P>> {
+      static displayName = wrapDisplayName(WrappedComponent, 'ToJunction');
 
-    root$: null | Pool<Action, Error>;
-    events: ExtraProps<E>;
-    sources: {
-      list: Observable<Action, Error>[];
-      dict: ObservableDict;
-      merged: Observable<Action, Error>;
-    };
-    children$: Pool<Action, Error>;
-    source$: any;
-
-    constructor(props: WithPreplug<Omit<P, keyof E>>) {
-      super(props);
-      this.root$ = null;
-      this.events = {} as ExtraProps<E>;
-
-      this.children$ = Kefir.pool();
-
-      this.sources = {
-        list: [this.children$],
-        dict: { children$: this.children$ },
-        merged: Kefir.never()
+      root$: null | Pool<Action, Error>;
+      events: ProvidedProps<E>;
+      sources: {
+        list: Observable<Action, Error>[];
+        dict: ObservableDict<E>;
+        merged: Observable<Action, Error>;
       };
+      children$: Pool<Action, Error>;
+      source$: Observable<Action, Error>;
 
-      for (const key in events) {
-        const e$ = new Kefir.Stream<Event, Error>();
-        this.events[key] = e => {
-          (e$ as any)._emitValue(e);
+      constructor(props: WithProps<E, P>) {
+        super(props);
+        this.root$ = null;
+        this.events = {} as ProvidedProps<E>;
+
+        this.children$ = Kefir.pool();
+
+        this.sources = {
+          list: [this.children$],
+          dict: { children$: this.children$ } as any,
+          merged: Kefir.never()
         };
-        this.sources.list.push(
-          (this.sources.dict[key + '$'] = events[key](e$))
+
+        for (const key in events) {
+          const e$ = new Kefir.Stream<Event, Error>();
+          this.events[key] = e => {
+            (e$ as any)._emitValue(e);
+          };
+          this.sources.list.push(
+            (this.sources.dict[key + '$'] = events[key](e$))
+          );
+        }
+
+        this.sources.merged = Kefir.merge(this.sources.list);
+        this.source$ = this.createSource();
+      }
+
+      createSource() {
+        const combined$ = combine(
+          this.sources.merged,
+          this.sources.dict,
+          this.props
+        );
+
+        if (this.props.preplug) {
+          return this.props.preplug(combined$);
+        }
+
+        return combined$;
+      }
+
+      unplug() {
+        this.root$ && this.root$.unplug(this.source$);
+      }
+
+      componentWillUnmount() {
+        this.unplug();
+      }
+
+      componentDidUpdate() {
+        this.unplug();
+        this.root$ && this.root$.plug((this.source$ = this.createSource()));
+      }
+
+      render() {
+        return (
+          <Consumer>
+            {root$ => {
+              if (root$ != null) {
+                if (this.root$ !== root$) {
+                  this.unplug();
+                  this.root$ = root$.plug(this.source$);
+                }
+              } else {
+                console.error(
+                  'Used `toJunction` outside of Silt context. Needs to be wrapped in `<RootJunction>`'
+                );
+              }
+
+              const props = {
+                ...this.props,
+                ...this.events
+              } as P;
+
+              return (
+                <Provider value={this.children$}>
+                  <WrappedComponent {...props} />
+                </Provider>
+              );
+            }}
+          </Consumer>
         );
       }
-
-      this.sources.merged = Kefir.merge(this.sources.list);
-      this.source$ = this.createSource();
-    }
-
-    createSource() {
-      const combined$ = combine(
-        this.sources.merged,
-        this.sources.dict,
-        this.props
-      );
-
-      if (this.props.preplug) {
-        return this.props.preplug(combined$);
-      }
-
-      return combined$;
-    }
-
-    unplug() {
-      this.root$ && this.root$.unplug(this.source$);
-    }
-
-    componentWillUnmount() {
-      this.unplug();
-    }
-
-    componentDidUpdate() {
-      this.unplug();
-      this.root$ && this.root$.plug((this.source$ = this.createSource()));
-    }
-
-    render() {
-      return (
-        <Consumer>
-          {root$ => {
-            if (root$ != null) {
-              if (this.root$ !== root$) {
-                this.unplug();
-                this.root$ = root$.plug(this.source$);
-              }
-            } else {
-              console.error(
-                'Used `toJunction` outside of Silt context. Needs to be wrapped in `<RootJunction>`'
-              );
-            }
-
-            const props = {
-              ...this.events,
-              ...this.props
-            } as P;
-
-            return (
-              <Provider value={this.children$}>
-                <WrappedComponent {...props} />
-              </Provider>
-            );
-          }}
-        </Consumer>
-      );
-    }
-  };
-
+    };
+}
 export default toJunction;


### PR DESCRIPTION
This should make it easier to define `toJunction` wrapped
Components without needing to type it manually.

Fix #374.