### PR TITLE
Prevent refback from being called repeatedly

### DIFF
--- a/packages/brookjs-silt/src/withRef.tsx
+++ b/packages/brookjs-silt/src/withRef.tsx
@@ -46,6 +46,8 @@ export const withRef$ = <P, E extends Element>(refback: Refback<P, E>) => (
 
     plugged$?: Observable<Action, Error>;
 
+    refback = (el: E | null) => el && (this.ref$ as any)._emitValue(el);
+
     componentWillUnmount() {
       this.aggregated$ &&
         this.plugged$ &&
@@ -85,12 +87,7 @@ export const withRef$ = <P, E extends Element>(refback: Refback<P, E>) => (
               );
             }
 
-            return (
-              <WithRef$.Target
-                {...this.props}
-                ref={(el: E | null) => el && (this.ref$ as any)._emitValue(el)}
-              />
-            );
+            return <WithRef$.Target {...this.props} ref={this.refback} />;
           }}
         </Consumer>
       );


### PR DESCRIPTION
If we provide a new callback every time, then React notifies the
callback of the latest ref every time as well. Reusing the callback
ensures it doesn't see it as a new callback to notify.