### PR TITLE
Fix exit code when build fails and not watching

### DIFF
--- a/packages/brookjs-cli/features/build.feature
+++ b/packages/brookjs-cli/features/build.feature
@@ -4,14 +4,23 @@ Feature: build command
   As a developer
   I want to use webpack to produce a distributible bundle
 
+  @development
   Scenario: Developer runs build with env development
     Given I have a project
     When I run beaver with "build --env development"
     And I wait for the command to finish with code 0
     Then I see "dist/app.js" with a file size between 1400000 and 1700000 bytes
 
+  @production
   Scenario: Developer runs build with env production
     Given I have a project
     When I run beaver with "build --env production"
     And I wait for the command to finish with code 0
     Then I see "dist/app.js" with a file size between 250000 and 300000 bytes
+
+  @broken
+  Scenario: Developer runs broken build
+    Given I have a project
+    And I import an unknown file
+    When I run beaver with "build --env development"
+    Then I wait for the command to finish with code 1

--- a/packages/brookjs-cli/features/support/steps.ts
+++ b/packages/brookjs-cli/features/support/steps.ts
@@ -68,6 +68,13 @@ Given('I have a project', { timeout: -1 }, async function() {
   await this.createProject();
 });
 
+Given('I import an unknown file', async function () {
+  await this.appendFile({
+    path: path.join('src', 'app.js'),
+    contents: "import './file-does-not-exist';\n"
+  });
+});
+
 /**
  * When I Do
  */
@@ -128,4 +135,11 @@ Then('I see {string} with a file size between {int} and {int} bytes', function(
   expect(fs.statSync(file).size)
     .to.be.above(lower)
     .and.below(upper);
+});
+
+Then('I expect the output to match the snapshot', async function() {
+  expect(this.output.stdout).to.matchSnapshot(
+    this.snapshot.filename,
+    `${this.snapshot.testname}-output`
+  );
 });

--- a/packages/brookjs-cli/features/support/world.ts
+++ b/packages/brookjs-cli/features/support/world.ts
@@ -123,6 +123,12 @@ class CliWorld implements World {
     return fs.appendFile(path.join(this.cwd, file.path), file.contents);
   }
 
+  async prependFile(file: File) {
+    const targetPath = path.join(this.cwd, file.path);
+    const contents = await fs.readFile(targetPath, 'utf-8');
+    return fs.outputFile(targetPath, file.contents + contents);
+  }
+
   getFile(file: string, barrel: string) {
     return fs.readFile(path.join(this.cwd, 'src', barrel, file), 'utf-8');
   }
@@ -191,18 +197,10 @@ class CliWorld implements World {
     }
   }
 
-  outputMatches(matches: string) {
-    return new Promise<void>(resolve => {
-      const loop = () => {
-        if (this.output.stdout.trim().includes(matches)) {
-          resolve();
-        } else {
-          setTimeout(loop, 200);
-        }
-      };
-
-      loop();
-    });
+  async outputMatches(matches: string) {
+    while (!this.output.stdout.trim().includes(matches)) {
+      await this.wait(200);
+    }
   }
 
   async ended() {


### PR DESCRIPTION
This makes sure the process exits with `1` if the build fails, which
should fix issues running this in CI with passing builds.

Fixes #381.