### PR TITLE
Refactor to use stream at center over useReducer

### DIFF
--- a/packages/brookjs-silt/src/useDeltas.ts
+++ b/packages/brookjs-silt/src/useDeltas.ts
@@ -1,15 +1,12 @@
 import {
-  useReducer,
   Reducer,
-  ReducerState,
-  ReducerAction,
   useEffect,
   useCallback,
   useMemo,
-  useLayoutEffect,
-  useRef
+  useRef,
+  useState
 } from 'react';
-import Kefir, { Observable } from 'kefir';
+import Kefir, { Observable, Property, Stream } from 'kefir';
 import { Delta } from 'brookjs-types';
 
 const useSingleton = <T>(creator: () => T): T => {
@@ -22,57 +19,51 @@ const useSingleton = <T>(creator: () => T): T => {
   return ref.current;
 };
 
-// Reuse this array to avoid React triggering rerenders.
-const defaultDeltas: any[] = [];
-
-const createAction$ = <R extends Reducer<any, any>>() =>
-  new Kefir.Stream<ReducerAction<R>, never>();
-
-const createState$ = <R extends Reducer<any, any>>() =>
-  new Kefir.Property<ReducerState<R>, never>();
-
-const useDeltas = <R extends Reducer<any, any>>(
-  reducer: R,
-  initialState: ReducerState<R>,
-  deltas: Delta<ReducerAction<R>, ReducerState<R>>[] = defaultDeltas
+const useSubscribe = <V>(
+  obs$: Observable<V, never>,
+  listener: (value: V) => void
 ) => {
-  const [state, _dispatch] = useReducer(reducer, initialState);
-
-  const actions$ = useSingleton(() => createAction$<R>());
-  const state$ = useSingleton(() => createState$<R>());
-  const lastAction = useRef<ReducerAction<R> | null>(null);
-
-  const dispatch = useCallback(
-    (action: ReducerAction<R>) => {
-      lastAction.current = action;
-      _dispatch(action);
-    },
-    [_dispatch]
-  );
-
-  useLayoutEffect(() => {
-    (state$ as any)._emitValue(state);
-    lastAction.current && (actions$ as any)._emitValue(lastAction.current);
-  }, [state, state$]);
-
-  const delta$ = useMemo(
-    () =>
-      Kefir.merge<ReducerAction<R>, never>(
-        deltas.map(delta => delta(actions$, state$))
-      ),
-    [...deltas, state$, actions$]
-  );
-
   useEffect(() => {
-    const sub = delta$.observe(dispatch);
+    const sub = obs$.observe(listener);
 
     return () => {
       sub.unsubscribe();
     };
-  }, [delta$, dispatch]);
+  }, [obs$, listener]);
+};
+
+// Reuse this array to avoid React triggering rerenders.
+const defaultDeltas: any[] = [];
+
+const useDeltas = <S, A>(
+  reducer: Reducer<S, A>,
+  initialState: S,
+  deltas: Delta<A, S>[] = defaultDeltas
+) => {
+  const action$: Stream<A, never> = useSingleton(() => new Kefir.Stream());
+  const state$: Property<S, never> = useMemo(
+    () => action$.scan(reducer, initialState),
+    [action$, reducer]
+  );
+  const [state, setState] = useState(initialState);
+
+  useSubscribe(state$, setState);
+
+  const delta$: Observable<A, never> = useMemo(
+    () => Kefir.merge(deltas.map(delta => delta(action$, state$))),
+    [...deltas, action$, state$]
+  );
+  const dispatch = useCallback(
+    (action: A) => {
+      (action$ as any)._emitValue(action);
+    },
+    [action$]
+  );
+
+  useSubscribe(delta$, dispatch);
 
   const root$ = useCallback(
-    (root$: Observable<ReducerAction<R>, Error>) => root$.observe(dispatch),
+    (root$: Observable<A, Error>) => root$.observe(dispatch),
     [dispatch]
   );
 


### PR DESCRIPTION
We'll use `#scan` to manage the reducer part of the flow and
then just pass that state over to `setState` for React to deal
with after.

Fixes #801.
Fixes #836.