### PR TITLE
Update `useDeltas` -> `useDelta`

### DIFF
--- a/packages/brookjs-cli/src/commands/BuildCommand/index.tsx
+++ b/packages/brookjs-cli/src/commands/BuildCommand/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { Argv } from 'yargs';
-import { useDeltas, RootJunction } from 'brookjs-silt';
+import { useDelta, RootJunction } from 'brookjs-silt';
 import { Command } from '../../cli';
 import * as project from '../../project';
 import exec from './exec';
@@ -25,10 +25,10 @@ const BuildCommand: Command<Args> = {
   },
 
   View: ({ args, rc, cwd }) => {
-    const { state, root$, dispatch } = useDeltas(
+    const { state, root$, dispatch } = useDelta(
       reducer,
       initialState(args, { rc, cwd }),
-      [exec]
+      exec
     );
 
     useEffect(() => {

--- a/packages/brookjs-cli/src/commands/NewCommand/index.tsx
+++ b/packages/brookjs-cli/src/commands/NewCommand/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDeltas, RootJunction } from 'brookjs-silt';
+import { useDelta, RootJunction } from 'brookjs-silt';
 import { Command } from '../../cli';
 import exec from './exec';
 import View from './View';
@@ -31,9 +31,11 @@ const NewCommand: Command<Args> = {
     });
   },
   View: ({ args, cwd }) => {
-    const { state, root$ } = useDeltas(reducer, initialState(args, { cwd }), [
+    const { state, root$ } = useDelta(
+      reducer,
+      initialState(args, { cwd }),
       exec
-    ]);
+    );
 
     return (
       <RootJunction root$={root$}>

--- a/packages/brookjs-cli/src/commands/TestCommand/Check/index.tsx
+++ b/packages/brookjs-cli/src/commands/TestCommand/Check/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useDeltas } from 'brookjs-silt';
+import { useDelta } from 'brookjs-silt';
 import { unreachable } from 'brookjs-types';
 import { Arguments } from 'yargs';
 import * as glob from '../../../glob';
@@ -14,7 +14,7 @@ const Check: React.FC<{ args: Arguments<Args>; rc: unknown; cwd: string }> = ({
   rc,
   cwd
 }) => {
-  const { state, dispatch } = useDeltas(reducer, initialState(cwd, rc), [exec]);
+  const { state, dispatch } = useDelta(reducer, initialState(cwd, rc), exec);
 
   useEffect(() => {
     dispatch(glob.actions.lint.request());

--- a/packages/brookjs-cli/src/commands/TestCommand/Lint/index.tsx
+++ b/packages/brookjs-cli/src/commands/TestCommand/Lint/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { useDeltas } from 'brookjs-silt';
+import { useDelta } from 'brookjs-silt';
 import { unreachable } from 'brookjs-types';
 import { Arguments } from 'yargs';
 import * as glob from '../../../glob';
@@ -14,7 +14,7 @@ const Lint: React.FC<{ args: Arguments<Args>; rc: unknown; cwd: string }> = ({
   rc,
   cwd
 }) => {
-  const { state, dispatch } = useDeltas(reducer, initialState(cwd, rc), [exec]);
+  const { state, dispatch } = useDelta(reducer, initialState(cwd, rc), exec);
 
   useEffect(() => {
     dispatch(glob.actions.lint.request());

--- a/packages/brookjs-cli/src/commands/TestCommand/Unit/index.tsx
+++ b/packages/brookjs-cli/src/commands/TestCommand/Unit/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDeltas, RootJunction } from 'brookjs-silt';
+import { useDelta, RootJunction } from 'brookjs-silt';
 import { Arguments } from 'yargs';
 import exec from './exec';
 import initialState from './initialState';
@@ -12,9 +12,11 @@ const Unit: React.FC<{ args: Arguments<Args>; rc: unknown; cwd: string }> = ({
   rc,
   cwd
 }) => {
-  const { state, root$ } = useDeltas(reducer, initialState(args, { rc, cwd }), [
+  const { state, root$ } = useDelta(
+    reducer,
+    initialState(args, { rc, cwd }),
     exec
-  ]);
+  );
 
   return (
     <RootJunction root$={root$}>

--- a/packages/brookjs-silt/src/__tests__/useDelta.spec.ts
+++ b/packages/brookjs-silt/src/__tests__/useDelta.spec.ts
@@ -3,7 +3,7 @@ import Kefir from 'kefir';
 import { ofType } from 'brookjs-flow';
 import { loop } from 'brookjs-eddy';
 import { renderHook, act } from '@testing-library/react-hooks';
-import useDeltas from '../useDeltas';
+import { useDelta } from '../useDelta';
 
 const { stream, send, value } = KTU;
 
@@ -11,7 +11,7 @@ type State = { counter: number };
 
 type Action = { type: string };
 
-describe('useDeltas', () => {
+describe('useDelta', () => {
   const initialState: State = {
     counter: 0
   };
@@ -28,7 +28,7 @@ describe('useDeltas', () => {
   };
 
   it('should return state, dispatch, and root$', () => {
-    const { result } = renderHook(() => useDeltas(reducer, initialState));
+    const { result } = renderHook(() => useDelta(reducer, initialState));
 
     expect(result.current).toEqual({
       state: initialState,
@@ -38,7 +38,7 @@ describe('useDeltas', () => {
   });
 
   it('should dispatch actions and update the state', () => {
-    const { result } = renderHook(() => useDeltas(reducer, initialState));
+    const { result } = renderHook(() => useDelta(reducer, initialState));
 
     act(() => {
       result.current.dispatch({ type: 'INCREMENT' });
@@ -50,7 +50,7 @@ describe('useDeltas', () => {
   });
 
   it('should dispatch actions from the root$ and unsubscribe as needed', () => {
-    const { result } = renderHook(() => useDeltas(reducer, initialState));
+    const { result } = renderHook(() => useDelta(reducer, initialState));
     const root$ = stream<any, any>();
     const sub = result.current.root$(root$);
 
@@ -76,9 +76,7 @@ describe('useDeltas', () => {
 
   it('should dispatch action & state to the provided delta', () => {
     const delta = jest.fn(() => Kefir.never());
-    const { result } = renderHook(() =>
-      useDeltas(reducer, initialState, [delta])
-    );
+    const { result } = renderHook(() => useDelta(reducer, initialState, delta));
 
     const [action$, state$] = delta.mock.calls[0] as any;
 
@@ -108,9 +106,7 @@ describe('useDeltas', () => {
     const delta: any = jest.fn(function() {
       return (delta$ = Kefir.pool());
     });
-    const { result } = renderHook(() =>
-      useDeltas(reducer, initialState, [delta])
-    );
+    const { result } = renderHook(() => useDelta(reducer, initialState, delta));
 
     act(() => {
       send(delta$, [value({ type: 'INCREMENT' })]);
@@ -123,9 +119,7 @@ describe('useDeltas', () => {
 
   it('should dispatch sync action from delta', () => {
     const delta = jest.fn(() => Kefir.constant({ type: 'INCREMENT' }));
-    const { result } = renderHook(() =>
-      useDeltas(reducer, initialState, [delta])
-    );
+    const { result } = renderHook(() => useDelta(reducer, initialState, delta));
 
     expect(result.current.state).toEqual({
       counter: 1
@@ -134,9 +128,7 @@ describe('useDeltas', () => {
 
   it('should dispatch action into delta if state does not change', () => {
     const delta = jest.fn(() => Kefir.never());
-    const { result } = renderHook(() =>
-      useDeltas(reducer, initialState, [delta])
-    );
+    const { result } = renderHook(() => useDelta(reducer, initialState, delta));
 
     const [action$, state$]: any = delta.mock.calls[0];
 
@@ -177,7 +169,7 @@ describe('useDeltas', () => {
           return { ...state, actions: [...state.actions, action.type] };
       }
     };
-    const { result } = renderHook(() => useDeltas(eddyReducer, initialState));
+    const { result } = renderHook(() => useDelta(eddyReducer, initialState));
 
     act(() => {
       result.current.dispatch({ type: 'INCREMENT' });
@@ -215,7 +207,7 @@ describe('useDeltas', () => {
     const delta = (action$: any) =>
       action$.thru(ofType('SQR_ROOT')).map(() => ({ type: 'THIRD' }));
     const { result } = renderHook(() =>
-      useDeltas(eddyReducer, initialState, [delta])
+      useDelta(eddyReducer, initialState, delta)
     );
 
     act(() => {

--- a/packages/brookjs-silt/src/index.ts
+++ b/packages/brookjs-silt/src/index.ts
@@ -1,6 +1,6 @@
 import RootJunction from './RootJunction';
 
 export * from './toJunction';
-export { default as useDeltas } from './useDeltas';
+export * from './useDelta';
 export * from './withRef';
 export { RootJunction };


### PR DESCRIPTION
Accept a single delta, so it matches the API for `createStore`.
Both of these accept a single delta. We should intead encourage
a root delta that combines them all together, providing a point
where the application state & actions can be decoupled from
an individual delta's. We could eventually provide a helper for
this process but start with suggesting manual combinations.