### PR TITLE
Run function in current context

### DIFF
--- a/packages/brookjs-cli/src/cli/App.tsx
+++ b/packages/brookjs-cli/src/cli/App.tsx
@@ -62,27 +62,24 @@ export class App {
 
     const exports = {};
     const module = { exports };
-    const context = vm.createContext({
-      module,
-      exports,
-      __dirname: path.dirname(filename),
-      process,
-      require: (target: string) => {
-        const resolvedTarget = App.resolve(target, path.dirname(filename));
 
-        if (
-          resolvedTarget.includes('node_modules') ||
-          !resolvedTarget.includes(path.sep)
-        ) {
-          return require(resolvedTarget);
-        }
-
-        return this.load(resolvedTarget);
+    vm.compileFunction(
+      result.code,
+      ['module', 'exports', '__dirname', 'require'],
+      {
+        filename
       }
-    });
+    )(module, exports, path.dirname(filename), (target: string) => {
+      const resolvedTarget = App.resolve(target, path.dirname(filename));
 
-    vm.runInNewContext(result.code, context, {
-      filename: filename
+      if (
+        resolvedTarget.includes('node_modules') ||
+        !resolvedTarget.includes(path.sep)
+      ) {
+        return require(resolvedTarget);
+      }
+
+      return this.load(resolvedTarget);
     });
 
     return module.exports;


### PR DESCRIPTION
If we keep it in this context, there's no cross-realm problems,
which webpack's validation chokes on. There add an `instanceof`
keyword to ajv, which they use to validate the regex & functions
passed in. Running in another context creates a new set of globals,
so those `instanceof` check fail.