### PR TITLE
Exclude .stories.js & __stories__ from coverage

### DIFF
--- a/packages/brookjs-cli/src/commands/TestCommand/Unit/exec.ts
+++ b/packages/brookjs-cli/src/commands/TestCommand/Unit/exec.ts
@@ -42,6 +42,8 @@ const exec = (
           `${dir}/**/*.{js,jsx,mjs,ts,tsx}`,
           `!${dir}/index.{js,jsx,mjs,ts,tsx}`,
           `!${dir}/**/__tests__/**`,
+          `!${dir}/**/__stories__/**`,
+          `!${dir}/**/*.stories.{js,jsx,mjs,ts,tsx}`,
           `!${dir}/**/*.d.ts`,
         ],
         setupFilesAfterEnv: setupTests,


### PR DESCRIPTION
These aren't tested separately so we don't need coverage for them.

Fixes #1075.