### PR TITLE
Make Central Observable error channel `never`

### DIFF
--- a/packages/brookjs-silt/src/RootJunction.tsx
+++ b/packages/brookjs-silt/src/RootJunction.tsx
@@ -5,16 +5,14 @@ import { Maybe } from 'brookjs-types';
 import { Provider, Consumer } from './context';
 
 type Props<A> = {
-  root$?: (p: Pool<A, Error>) => Maybe<Subscription>;
+  root$?: (p: Pool<A, never>) => Maybe<Subscription>;
   children: React.ReactNode;
 };
 
-export default class RootJunction<A extends Action> extends React.Component<
-  Props<A>
-> {
-  childRoot$: Pool<A, Error> = Kefir.pool();
+export class RootJunction<A extends Action> extends React.Component<Props<A>> {
+  childRoot$: Pool<A, never> = Kefir.pool();
   sub?: Maybe<Subscription>;
-  parentRoot$?: Maybe<Pool<A, Error>>;
+  parentRoot$?: Maybe<Pool<A, never>>;
 
   unplug() {
     this.parentRoot$?.unplug(this.childRoot$);

--- a/packages/brookjs-silt/src/__tests__/RootJunction.spec.tsx
+++ b/packages/brookjs-silt/src/__tests__/RootJunction.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React from 'react';
 import { render } from '@testing-library/react';
-import RootJunction from '../RootJunction';
+import { RootJunction } from '../RootJunction';
 
 describe('RootJunction', () => {
   it('should provide aggregated$ as context', () => {

--- a/packages/brookjs-silt/src/__tests__/toJunction.spec.tsx
+++ b/packages/brookjs-silt/src/__tests__/toJunction.spec.tsx
@@ -161,7 +161,7 @@ describe('toJunction', () => {
     };
 
     it('should call combine with correct arguments and use returned stream', () => {
-      const source$ = stream<any, any>();
+      const source$ = stream<any, never>();
       const combine: Combiner<Props, typeof events> = jest.fn(() => source$);
       const _Button: React.FC<Props> = ({ onButtonClick, text, enabled }) =>
         enabled ? (
@@ -252,7 +252,7 @@ describe('toJunction', () => {
 
   describe('preplug', () => {
     it('should map stream', () => {
-      const root$ = pool<any, any>();
+      const root$ = pool<any, never>();
       const wrapper = render(
         <Provider value={root$}>
           <Button
@@ -269,7 +269,7 @@ describe('toJunction', () => {
     });
 
     it('should map children', () => {
-      const root$ = pool<any, any>();
+      const root$ = pool<any, never>();
       const Wrapper = toJunction()(() => (
         <Button text={'Click me'} enabled={true} />
       ));

--- a/packages/brookjs-silt/src/__tests__/withRef.spec.tsx
+++ b/packages/brookjs-silt/src/__tests__/withRef.spec.tsx
@@ -24,7 +24,7 @@ const _Button: React.RefForwardingComponent<HTMLButtonElement, Props> = (
 
 const Button = withRef$(refback)(_Button);
 
-const Instance: React.FC<Props & { aggregated$: Pool<any, any> }> = ({
+const Instance: React.FC<Props & { aggregated$: Pool<any, never> }> = ({
   children,
   aggregated$,
 }) => (
@@ -45,7 +45,7 @@ describe('withRef$', () => {
   });
 
   it('should emit value from ref$', () => {
-    const aggregated$ = Kefir.pool();
+    const aggregated$ = Kefir.pool<any, never>();
     const wrapper = render(
       <Instance children={'Click me!'} aggregated$={aggregated$} />,
     );
@@ -62,7 +62,7 @@ describe('withRef$', () => {
   });
 
   it('should remove ref$ when unmounted', () => {
-    const aggregated$ = Kefir.pool();
+    const aggregated$ = Kefir.pool<any, never>();
     const wrapper = render(
       <Instance children={'Click me!'} aggregated$={aggregated$} />,
     );
@@ -73,8 +73,8 @@ describe('withRef$', () => {
   });
 
   it('should replace aggregated$', () => {
-    const aggregated$ = Kefir.pool();
-    const newAggregated$ = Kefir.pool();
+    const aggregated$ = Kefir.pool<any, never>();
+    const newAggregated$ = Kefir.pool<any, never>();
     const wrapper = render(
       <Instance children={'Click me!'} aggregated$={aggregated$} />,
     );
@@ -98,7 +98,7 @@ describe('withRef$', () => {
   });
 
   it('should emit new props', () => {
-    const aggregated$ = Kefir.pool();
+    const aggregated$ = Kefir.pool<any, never>();
     const wrapper = render(
       <Instance children={'Click me!'} aggregated$={aggregated$} />,
     );
@@ -126,7 +126,7 @@ describe('withRef$', () => {
   });
 
   it('should work with components that can take a ref directly', () => {
-    const aggregated$ = Kefir.pool();
+    const aggregated$ = Kefir.pool<any, never>();
     const Button = withRef$(refback)('button');
     const Instance: React.FC<any> = ({ text, aggregated$ }) => (
       <Provider value={aggregated$}>

--- a/packages/brookjs-silt/src/context.ts
+++ b/packages/brookjs-silt/src/context.ts
@@ -4,7 +4,7 @@ import { createContext } from 'react';
 
 export const CentralObservableContext = createContext<Pool<
   Action,
-  Error
+  never
 > | null>(null);
 
 export const { Provider, Consumer } = CentralObservableContext;

--- a/packages/brookjs-silt/src/index.ts
+++ b/packages/brookjs-silt/src/index.ts
@@ -1,6 +1,4 @@
-import RootJunction from './RootJunction';
-
+export * from './RootJunction';
 export * from './toJunction';
 export * from './useDelta';
 export * from './withRef';
-export { RootJunction };

--- a/packages/brookjs-silt/src/toJunction.tsx
+++ b/packages/brookjs-silt/src/toJunction.tsx
@@ -7,9 +7,9 @@ import { wrapDisplayName } from './wrapDisplayName';
 const id = <T extends any>(x: T) => x;
 
 type ObservableDict<E extends { [key: string]: any }> = {
-  [K in keyof E]: Observable<Action, Error>;
+  [K in keyof E]: Observable<Action, never>;
 } & {
-  children$: Observable<Action, Error>;
+  children$: Observable<Action, never>;
 };
 
 type ProvidedProps<E extends { [key: string]: any }> = {
@@ -21,15 +21,15 @@ type WithProps<E extends { [key: string]: any }, P extends {}> = Omit<
   keyof E
 > & {
   preplug?: (
-    source$: Observable<Action<string>, Error>,
-  ) => Observable<Action<string>, Error>;
+    source$: Observable<Action<string>, never>,
+  ) => Observable<Action<string>, never>;
 };
 
 export type Combiner<P extends {}, E extends { [key: string]: any } = {}> = (
-  combined$: Observable<Action, Error>,
+  combined$: Observable<Action, never>,
   sources: ObservableDict<E>,
   props: Readonly<WithProps<E, P>>,
-) => Observable<Action, Error>;
+) => Observable<Action, never>;
 
 type Events<E> = {
   [K in keyof E]: (
@@ -61,15 +61,15 @@ export function toJunction<E extends { [key: string]: any }, P extends {}>(
     class ToJunction extends React.Component<WithProps<E, P>> {
       static displayName = wrapDisplayName(WrappedComponent, 'ToJunction');
 
-      root$: null | Pool<Action, Error>;
+      root$: null | Pool<Action, never>;
       events: ProvidedProps<E>;
       sources: {
-        list: Observable<Action, Error>[];
+        list: Observable<Action, never>[];
         dict: ObservableDict<E>;
-        merged: Observable<Action, Error>;
+        merged: Observable<Action, never>;
       };
-      children$: Pool<Action, Error>;
-      source$: Observable<Action, Error>;
+      children$: Pool<Action, never>;
+      source$: Observable<Action, never>;
 
       constructor(props: WithProps<E, P>) {
         super(props);

--- a/packages/brookjs-silt/src/withRef.tsx
+++ b/packages/brookjs-silt/src/withRef.tsx
@@ -23,7 +23,7 @@ const wrap = <E, P>(
 export type Refback<P, E extends Element, R extends { type: string }> = (
   ref$: Property<E, never>,
   props$: Property<P, never>,
-) => Observable<R, Error>;
+) => Observable<R, never>;
 
 export const withRef$ = <P, E extends Element, R extends { type: string }>(
   refback: Refback<P, E, R>,
@@ -46,9 +46,9 @@ export const withRef$ = <P, E extends Element, R extends { type: string }>(
       `${WithRef$.displayName}#ref$`,
     );
 
-    aggregated$?: Pool<Action, Error>;
+    aggregated$?: Pool<Action, never>;
 
-    plugged$?: Observable<Action, Error>;
+    plugged$?: Observable<Action, never>;
 
     refback = (el: E | null) => el && (this.ref$ as any)._emitValue(el);
 


### PR DESCRIPTION
We don't actually want to allow errors to be emitted from these.
We should throw/show an error if we get errors because they're
not really handled by anyone anywhere.