### PR TITLE
Fix useDelta plugging into the Central Observable

### DIFF
--- a/packages/brookjs-silt/src/hooks.ts
+++ b/packages/brookjs-silt/src/hooks.ts
@@ -1,0 +1,23 @@
+import { useRef, useEffect } from 'react';
+import { Observable } from 'kefir';
+
+export const useSingleton = <T>(creator: () => T): T => {
+  const ref = useRef<T | null>(null);
+  if (ref.current == null) {
+    ref.current = creator();
+  }
+  return ref.current;
+};
+
+export const useSubscribe = <V>(
+  obs$: Observable<V, never>,
+  listener: (value: V) => void,
+) => {
+  useEffect(() => {
+    const sub = obs$.observe(listener);
+
+    return () => {
+      sub.unsubscribe();
+    };
+  }, [obs$, listener]);
+};


### PR DESCRIPTION
We should plug in the `action$` stream, not the `delta$` stream,
because that one has the full set of actions emitted.

Also extract the hooks for reuse later.