### PR TITLE
Stop forwarding preplug

### DIFF
--- a/packages/brookjs-silt/src/toJunction.tsx
+++ b/packages/brookjs-silt/src/toJunction.tsx
@@ -140,15 +140,12 @@ export function toJunction<E extends { [key: string]: any }, P extends {}>(
                 );
               }
 
-              const props = {
-                ...this.props,
-                ...this.events,
-                // @TODO(mAAdhaTTah) would be nice for this to type right.
-              } as any;
+              const { preplug, ...props } = this.props;
 
               return (
                 <Provider value={this.children$}>
-                  <WrappedComponent {...props} />
+                  {/* TODO(mAAdhaTTah) would be nice for this to type right. */}
+                  <WrappedComponent {...this.events} {...(props as any)} />
                 </Provider>
               );
             }}


### PR DESCRIPTION
This prop is only used by the wrapper component and shouldn't
be passed along to the wrapped component.