### PR TITLE
Simplify toJunction implementation

### DIFF
--- a/packages/brookjs-cli/src/commands/NewCommand/__tests__/View.spec.tsx
+++ b/packages/brookjs-cli/src/commands/NewCommand/__tests__/View.spec.tsx
@@ -324,7 +324,7 @@ describe('NewCommand#View', () => {
     it('should respond to confirm', () => {
       let r$;
 
-      const { stdin } = render(
+      const element = (
         <RootJunction root$={root$ => void (r$ = root$)}>
           <View
             error={null}
@@ -342,8 +342,13 @@ describe('NewCommand#View', () => {
               typescript: false,
             }}
           />
-        </RootJunction>,
+        </RootJunction>
       );
+      const { stdin, rerender } = render(element);
+
+      // @TODO(mAAdhaTTah) needed to flush effects
+      // remove when this is fixed: https://github.com/vadimdemedes/ink-testing-library/issues/3
+      rerender(element);
 
       expect(r$).toEmit(
         [value({ type: 'CONFIRM', payload: { value: true } })],

--- a/packages/brookjs-silt/src/context.ts
+++ b/packages/brookjs-silt/src/context.ts
@@ -1,6 +1,6 @@
 import { Pool } from 'kefir';
 import { Action } from 'redux';
-import { createContext } from 'react';
+import { createContext, useContext } from 'react';
 
 export const CentralObservableContext = createContext<Pool<
   Action,
@@ -8,3 +8,5 @@ export const CentralObservableContext = createContext<Pool<
 > | null>(null);
 
 export const { Provider, Consumer } = CentralObservableContext;
+
+export const useCentralObservable = () => useContext(CentralObservableContext);


### PR DESCRIPTION
This is a breaking change, as `toJunction`'s `combine` function
now only accepts the resulting combined stream. This makes
it so we don't need to unplug & replug this stream on every
props change. We instead will just need the parent component
to ensure reusing the same function for `preplug`.