### PR TITLE
Plug events created by useDelta

### DIFF
--- a/packages/brookjs-silt/src/__tests__/useDelta.spec.ts
+++ b/packages/brookjs-silt/src/__tests__/useDelta.spec.ts
@@ -51,7 +51,7 @@ describe('useDelta', () => {
 
   it('should dispatch actions from the root$ and unsubscribe as needed', () => {
     const { result } = renderHook(() => useDelta(reducer, initialState));
-    const root$ = stream<any, any>();
+    const root$ = stream<any, never>();
     const sub = result.current.root$(root$);
 
     act(() => {


### PR DESCRIPTION
Plugging events from `dispatch` & `root$` causes duplicate events
to be pushed into the Central Observable. This ensures only events
created within `useDelta` (from the eddy reducer & the delta) are
pushed.