### PR TITLE
Wrap rerender in RootJunction

### DIFF
--- a/packages/brookjs-desalinate/src/jestPlugin.tsx
+++ b/packages/brookjs-desalinate/src/jestPlugin.tsx
@@ -74,9 +74,15 @@ export const jestPlugin = ({
             });
           };
 
-          const api = render(
+          const { rerender, ...rr } = render(
             <RootJunction root$={root$}>{element}</RootJunction>,
           );
+
+          const api = {
+            ...rr,
+            rerender: (element: React.ReactElement) =>
+              rerender(<RootJunction root$={root$}>{element}</RootJunction>),
+          };
 
           cb(api, actTick, clock);
           tick(timeLimit);


### PR DESCRIPTION
This allows components to update during tests without
needed to wrap the element in RootJunction, similar to
how we do it in the initial render.